### PR TITLE
fix: address recurring failure in periodic-cluster-api-provider-azure-apiversion-upgrade-main

### DIFF
--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -399,7 +399,7 @@ spec:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE:=Standard_D4s_v5}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate


### PR DESCRIPTION
> [!WARNING]
> Draft PR auto-proposed by a CI failure-analysis dashboard. Review carefully before use; the change is a starting point, not a verified fix.

**Proposed change:** Default the control plane VM SKU to Standard_D4s_v5 in the upgrades template to handle the transient load during CRD upgrades.

**Recurring failure:** periodic-cluster-api-provider-azure-apiversion-upgrade-main
**Shared root cause:** During 'clusterctl upgrade', the transition of the Azure Service Operator (ASO) controller causes a startup deadlock. The new 'azureserviceoperator-controller-manager' attempts to sync its cache for ASO resources, which triggers conversion webhook calls that fail (due to connection refused or transient TLS/cert-manager bootstrap lags). This blocks the operator from becoming ready, overloading the control plane (etcd and kube-apiserver timeouts) and consistently exceeding the 5-minute upgrade readiness timeout.
**Builds analyzed:** 5 (confidence: high)

**Before merging, a human must:**
- Verify the change actually fixes the root cause (run the affected job).
- Confirm it follows the project's conventions and doesn't regress other flavors.

<details><summary>Proposed diff</summary>

```diff
--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
-       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE:=Standard_D4s_v5}
```
</details>

Dashboard: https://willie-yao.github.io/capz-prow-ai-dashboard

<!-- prow-ai-dashboard-fix:3c3139c0b0c75eb2 -->
