### PR TITLE
fix: address recurring failure in periodic-cluster-api-provider-azure-e2e-fixdemo

### DIFF
--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -28,7 +28,7 @@ const (
 	// DefaultAzureServiceReconcileTimeout is the default timeout for an Azure service reconcile.
 	DefaultAzureServiceReconcileTimeout = 12 * time.Second
 	// DefaultAzureCallTimeout is the default timeout for an Azure request after which an Azure operation is considered long running.
-	DefaultAzureCallTimeout = 2 * time.Second
+	DefaultAzureCallTimeout = 10 * time.Second
 	// DefaultReconcilerRequeue is the default value for the reconcile retry.
 	DefaultReconcilerRequeue = 15 * time.Second
 	// DefaultHTTP429RetryAfter is a default backoff wait time when we get a HTTP 429 response with no Retry-After data.


### PR DESCRIPTION
> [!WARNING]
> Draft PR auto-proposed by a CI failure-analysis dashboard. Review carefully before use; the change is a starting point, not a verified fix.

**Proposed change:** Increase DefaultAzureCallTimeout from 2 to 10 seconds to prevent premature cancellation of slow Azure ARM calls under load.

**Recurring failure:** periodic-cluster-api-provider-azure-e2e-fixdemo
**Shared root cause:** The Azure service reconcile repeatedly hits 'context deadline exceeded' because DefaultAzureCallTimeout (2s) in util/reconciler/defaults.go is too low for slow ARM responses under load, so long-running Azure calls are cut off before they complete.
**Builds analyzed:** 6 (confidence: high)

**Before merging, a human must:**
- Verify the change actually fixes the root cause (run the affected job).
- Confirm it follows the project's conventions and doesn't regress other flavors.

<details><summary>Proposed diff</summary>

```diff
--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
- 	// DefaultAzureCallTimeout is the default timeout for an Azure request after which an Azure operation is considered long running.
- 	DefaultAzureCallTimeout = 2 * time.Second
+ 	// DefaultAzureCallTimeout is the default timeout for an Azure request after which an Azure operation is considered long running.
+ 	DefaultAzureCallTimeout = 10 * time.Second
```
</details>

Dashboard: http://localhost:8080

<!-- prow-ai-dashboard-fix:beac3ae7e0f3aaaf -->
