### PR TITLE
fix: address recurring failure in Azure throttling hot-loop from a past-dated Retry-After header

### DIFF
--- a/azure/services/async/async.go
+++ b/azure/services/async/async.go
@@ -196,7 +196,9 @@ func getRetryAfterFromError(err error) time.Duration {
 				ret = time.Duration(rai) * time.Second
 				// This handles the case where Retry-After data is in the form of absolute time
 			} else if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
-				ret = time.Until(t)
+				if d := time.Until(t); d > 0 {
+					ret = d
+				}
 			}
 			// If we didn't find Retry-After HTTP header data but the response type is 429,
 			// we'll have to come up with our sane default.


### PR DESCRIPTION
> [!WARNING]
> Draft PR auto-proposed by a CI failure-analysis dashboard. Review carefully before use; the change is a starting point, not a verified fix.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug

**What this PR does / why we need it**:

Guards the RFC1123 Retry-After branch so expired or clock-skewed timestamps fall back to the default requeue instead of a non-positive duration that causes an immediate hot-loop.

When Azure returns an HTTP 429 with a Retry-After header expressed as an absolute RFC1123 timestamp that is already in the past (server clock skew, or a retry-after that elapsed before the controller re-read it), getRetryAfterFromError computes time.Until(t), which is negative or zero. That non-positive duration is handed to controller-runtime as the requeue-after, so the reconciler requeues immediately and hot-loops against the throttled Azure API instead of backing off, amplifying the throttling that caused the 429 in the first place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

Recurring failure: Azure throttling hot-loop from a past-dated Retry-After header.

Builds analyzed: 4 (confidence: high).

Before merging, a human must:
- Verify the change actually fixes the root cause (run the affected job).
- Confirm it follows the project's conventions and doesn't regress other flavors.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where expired or clock-skewed RFC1123 Retry-After headers caused controllers to hot-loop instead of falling back to the default requeue interval.
```

<details><summary>Proposed diff</summary>

```diff
--- a/azure/services/async/async.go
+++ b/azure/services/async/async.go
- 			// This handles the case where Retry-After data is in the form of units of seconds
- 			if rai, err := strconv.Atoi(retryAfter); err == nil {
- 				ret = time.Duration(rai) * time.Second
- 				// This handles the case where Retry-After data is in the form of absolute time
- 			} else if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
- 				ret = time.Until(t)
- 			}
+ 			// This handles the case where Retry-After data is in the form of units of seconds
+ 			if rai, err := strconv.Atoi(retryAfter); err == nil {
+ 				ret = time.Duration(rai) * time.Second
+ 				// This handles the case where Retry-After data is in the form of absolute time
+ 			} else if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+ 				if d := time.Until(t); d > 0 {
+ 					ret = d
+ 				}
+ 			}
```
</details>

Dashboard: http://localhost:8080

<!-- prow-ai-dashboard-fix:3db1eddfcb3ebc0b -->
